### PR TITLE
[CON-2] [CON-4] Address malformed tables in UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "react-simple-code-editor": "^0.13.1",
         "redux": "^4.2.0",
         "uuid": "^9.0.0",
-        "wagmi": "^0.7.10"
+        "wagmi": "0.7.15"
       },
       "devDependencies": {
         "@babel/preset-react": "^7.17.12",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "react-simple-code-editor": "^0.13.1",
     "redux": "^4.2.0",
     "uuid": "^9.0.0",
-    "wagmi": "^0.7.10"
+    "wagmi": "0.7.15"
   },
   "devDependencies": {
     "@babel/preset-react": "^7.17.12",

--- a/src/app/components/ContextProviders.tsx
+++ b/src/app/components/ContextProviders.tsx
@@ -32,12 +32,7 @@ const localTableland: Chain = {
     symbol: 'LCTBL',
   },
   rpcUrls: {
-    default:  {
-      http: ["localhost:8080"]      
-    },
-    public:  {
-      http: ["localhost:8080"]      
-    },
+    default: "localhost:8080"
   },
   // blockExplorers: {
   //   default: { name: 'SnowTrace', url: 'https://snowtrace.io' },

--- a/src/app/components/ContextProviders.tsx
+++ b/src/app/components/ContextProviders.tsx
@@ -12,12 +12,12 @@ import {
   Chain
 } from '@rainbow-me/rainbowkit';
 import {
-  chain,
   configureChains,
   createClient,
   WagmiConfig,
 } from 'wagmi';
 import { publicProvider } from 'wagmi/providers/public';
+import * as chain from 'wagmi/chains';
 
 
 const localTableland: Chain = {
@@ -32,7 +32,12 @@ const localTableland: Chain = {
     symbol: 'LCTBL',
   },
   rpcUrls: {
-    default: "localhost:8080",
+    default:  {
+      http: ["localhost:8080"]      
+    },
+    public:  {
+      http: ["localhost:8080"]      
+    },
   },
   // blockExplorers: {
   //   default: { name: 'SnowTrace', url: 'https://snowtrace.io' },

--- a/src/app/components/atoms/Logo.tsx
+++ b/src/app/components/atoms/Logo.tsx
@@ -10,7 +10,7 @@ function Logo() {
           className='navbar--logo' 
         /> 
         <span className="navbar--logo_text">
-          Tableland™ <span>Console</span>
+          Tableland <span>Console</span>
         </span>
     </Link>
   );

--- a/src/app/components/molecules/TableList.tsx
+++ b/src/app/components/molecules/TableList.tsx
@@ -116,7 +116,7 @@ function TableList() {
       malformedTables.length > 0 && showMalformed && (
         <div className="malformed-tables-message message">
           <div className="error">
-            These tables are malformed and cannot be queried: {malformedTables.join(", ")}
+            You own malformed table. This may be because of malformed create statements. These have been omitted. {malformedTables.join(", ")}
             <br />
               <i className="fa fa-x exit" onClick={()=>setShowMalformed(!showMalformed)}></i>
           </div>

--- a/src/app/components/molecules/TableList.tsx
+++ b/src/app/components/molecules/TableList.tsx
@@ -92,8 +92,10 @@ function TableListItem(props) {
 
 function TableList() {
 
-
+  const malformedTables = useSelector((store: RootState) => store.pageState.malformedTables);
   const list = useSelector((store: RootState) => store.tables.list);
+
+  const [showMalformed, setShowMalformed] = useState(true);
 
   const network = useNetwork();  
   
@@ -109,6 +111,17 @@ function TableList() {
     <>
     {
       list.map(table => <TableListItem key={table.name} tableName={table.name} />)
+    }
+    {
+      malformedTables.length > 0 && showMalformed && (
+        <div className="malformed-tables-message message">
+          <div className="error">
+            These tables are malformed and cannot be queried: {malformedTables.join(", ")}
+            <br />
+              <i className="fa fa-x exit" onClick={()=>setShowMalformed(!showMalformed)}></i>
+          </div>
+        </div>
+      )
     }
     </>
   )

--- a/src/app/components/molecules/TableList.tsx
+++ b/src/app/components/molecules/TableList.tsx
@@ -116,7 +116,7 @@ function TableList() {
       malformedTables.length > 0 && showMalformed && (
         <div className="malformed-tables-message message">
           <div className="error">
-            You own malformed table. This may be because of malformed create statements. These have been omitted. {malformedTables.join(", ")}
+            You own at least one malformed table. This may be because of malformed create statements. These have been omitted. {malformedTables.join(", ")}
             <br />
               <i className="fa fa-x exit" onClick={()=>setShowMalformed(!showMalformed)}></i>
           </div>

--- a/src/app/components/organisms/CreateTable.tsx
+++ b/src/app/components/organisms/CreateTable.tsx
@@ -133,6 +133,7 @@ function CreateTable(props) {
           pattern='[a-zA-Z0-9_]*'
           title={"Letter, numbers, and underscores only. First character cannot be a number"}
           value={prefix} 
+          required={true}
           onChange={e => {
             dispatch(setPrefix({prefix: e.target.value, tabId}));
           }} />

--- a/src/app/store/pageStateSlice.ts
+++ b/src/app/store/pageStateSlice.ts
@@ -3,7 +3,8 @@ import { createSlice } from '@reduxjs/toolkit'
 const initialState = {
   settingsMenu: false,
   transactionsMenu: false,
-  chainMenu: false
+  chainMenu: false,
+  malformedTables: []
 };
 
 const pageStateSlice = createSlice({
@@ -21,9 +22,12 @@ const pageStateSlice = createSlice({
     },
     toggleMenu(state, action) {
       state[action.payload] = !state[action.payload]
+    },
+    addMalformedTable(state, action) {
+      state.malformedTables.push(action.payload);
     }
   }
 })
 
-export const { closeMenu, toggleMenu } = pageStateSlice.actions
+export const { closeMenu, toggleMenu, addMalformedTable } = pageStateSlice.actions
 export default pageStateSlice.reducer

--- a/src/app/store/tablesSlice.ts
+++ b/src/app/store/tablesSlice.ts
@@ -1,5 +1,7 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
 import { getTablelandConnection } from '../database/connectToTableland';
+import { addMalformedTable } from './pageStateSlice';
+import store from './store';
 
 export const getSchema = createAsyncThunk('tables/getSchema', async (action: any) => {
 
@@ -44,8 +46,7 @@ function rateLimitedTableMetaFetch(tables: Array<{chainId: number, tableId: stri
                   results.push(result);
               })
               .catch(error => {
-                console.error(error.message);
-                console.error(`Table ${tables[ii].tableId} does not exist. The table's Create statement may have been malformed.`);
+                store.dispatch(addMalformedTable(tables[ii].tableId));  
               });
           i++;
       }, 100);

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -12,31 +12,15 @@ try {
 
 
 app.listen(port, () => {
-    console.log(`Listening on port ${port}`);
-    
+    console.log(`Listening on port ${port}`);    
 });
-
-
-app.use((req, res, next) => {
-
-    // These headers are required for SharedArrayBuffer to work on app 
-    res.set({
-        'Access-Control-Allow-Origin': '*'
-        // 'Cross-Origin-Opener-Policy': 'same-origin',
-        // 'Cross-Origin-Embedder-Policy': 'require-corp'
-    })
-    next();
-})
 
 
 app.get("/", (req, res, next) => {
+    
     res.send(fs.readFileSync('src/app/index.html', 'utf-8'));
 
 })
 
 
-app.use('/', express.static('dist/public'));
-
-app.get(['/about', '/table-design', "^/table/:tableId", "/browse", "/my-tables", "/execute", "/chain/:chainId/table/:tableId", "/table"], (req, res, next) => {
-    res.send(fs.readFileSync('src/app/index.html', 'utf-8'));
-});
+app.use('/', express.static('public'));

--- a/src/styles/style.scss
+++ b/src/styles/style.scss
@@ -155,6 +155,15 @@ body {
   color: var(--error-dark);
   font-weight: 900;
   margin-bottom: 10px;
+  position: relative;
+  padding-right: 35px;
+  .exit {
+    position: absolute;
+    top: 0px;
+    right: 0px;
+    padding:10px;
+    cursor: pointer;
+  }
 }
 
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "trailingSlash": false,
+  "github": {
+    "silent": true
+  }
+}


### PR DESCRIPTION
Several errors related to malformed tables were being logged to the console. This adds an error message at the bottom of the Table List panel to address the errors instead. 

Note: The pull request also removes the "TM" in the logo.